### PR TITLE
Fix formatting in the doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,16 @@ all: install doc
 doc:
 	etc/make-doc.sh
 
+doctest:
+	(cd docs && make doctest)
+
 install:
 	pip3 install . --use-feature=in-tree-build
 
 black:
 	black setup.py tests/*.py libsemigroups_pybind11/*.py
 
-check:
+check: doctest
 	pytest -vv tests/test_*.py
 
 lint:

--- a/docs/source/action.rst
+++ b/docs/source/action.rst
@@ -14,9 +14,9 @@ This page contains details of the `RowActionBMat8` and `LeftAction` classes in
 notion of an "action" in the context of ``libsemigroups_pybind11`` is analogous to the
 notion of an orbit of a group.
 
-The function :any:`RowActionBMat8.run` finds points that can be obtained by acting
+The function :any:`run <Runner.run>` finds points that can be obtained by acting
 on the seeds of ``self`` by the generators of ``self`` until no further points
-can be found, or :any:`RowActionBMat8.stopped` returns ``True``.  This is achieved
+can be found, or :any:`stopped <Runner.stopped>` returns ``True``.  This is achieved
 by performing a breadth first search.
 
 In this documentation we refer to:
@@ -91,11 +91,13 @@ Contents
 RightAction Methods
 -------------------
 .. autoclass:: RowActionBMat8
-    :no-undoc-members:
     :members:
+    :show-inheritance:
+    :class-doc-from: class
+
+    .. autofunction:: libsemigroups_pybind11.action.RightAction
 
 Runner Methods
 --------------
-.. autoclass:: RowActionBMat8
-   :noindex:
-   :inherited-members:
+.. autoclass:: Runner
+    :members:

--- a/docs/source/action.rst
+++ b/docs/source/action.rst
@@ -30,37 +30,41 @@ In this documentation we refer to:
 .. doctest::
 
   >>> from libsemigroups_pybind11 import RightAction, BMat8
-  ... o = RightAction(element=BMat8, point=BMat8)
-  ... o.add_seed(BMat8([[1, 1, 1, 0], 
-  ...                   [1, 1, 0, 0], 
-  ...                   [0, 1, 0, 1], 
-  ...                   [0, 1, 0, 0]]).row_space_basis())
-  ... o.add_generator(
-  ...     BMat8([[1, 0, 0, 0], 
-  ...            [0, 1, 0, 0], 
-  ...            [0, 0, 1, 0], 
-  ...            [0, 0, 0, 1]]))
-  ... o.add_generator(
-  ...     BMat8([[0, 1, 0, 0], 
-  ...            [1, 0, 0, 0], 
-  ...            [0, 0, 1, 0], 
-  ...            [0, 0, 0, 1]]))
-  ... o.add_generator(
-  ...     BMat8([[0, 1, 0, 0], 
-  ...            [0, 0, 1, 0], 
-  ...            [0, 0, 0, 1], 
-  ...            [1, 0, 0, 0]]))
-  ... o.add_generator(
-  ...     BMat8([[1, 0, 0, 0], 
-  ...            [0, 1, 0, 0], 
-  ...            [0, 0, 1, 0], 
-  ...            [1, 0, 0, 1]]))
-  ... o.add_generator(
-  ...     BMat8([[1, 0, 0, 0], 
-  ...            [0, 1, 0, 0], 
-  ...            [0, 0, 1, 0], 
-  ...            [0, 0, 0, 0]]))
-  ... o.size()
+  >>> o = RightAction(element=BMat8, point=BMat8)
+  >>> o.add_seed(
+  ...     BMat8(
+  ...         [[1, 1, 1, 0],
+  ...          [1, 1, 0, 0],
+  ...          [0, 1, 0, 1],
+  ...          [0, 1, 0, 0]]).row_space_basis()
+  ... ).add_generator(
+  ...     BMat8([[1, 0, 0, 0],
+  ...            [0, 1, 0, 0],
+  ...            [0, 0, 1, 0],
+  ...            [0, 0, 0, 1]])
+  ... ).add_generator(
+  ...     BMat8([[0, 1, 0, 0],
+  ...            [1, 0, 0, 0],
+  ...            [0, 0, 1, 0],
+  ...            [0, 0, 0, 1]])
+  ... ).add_generator(
+  ...     BMat8([[0, 1, 0, 0],
+  ...            [0, 0, 1, 0],
+  ...            [0, 0, 0, 1],
+  ...            [1, 0, 0, 0]])
+  ... ).add_generator(
+  ...     BMat8([[1, 0, 0, 0],
+  ...            [0, 1, 0, 0],
+  ...            [0, 0, 1, 0],
+  ...            [1, 0, 0, 1]])
+  ... ).add_generator(
+  ...     BMat8([[1, 0, 0, 0],
+  ...            [0, 1, 0, 0],
+  ...            [0, 0, 1, 0],
+  ...            [0, 0, 0, 0]])
+  ... )
+  <open right action with 5 generators, 1 points>
+  >>> o.size()
   553
 
 Contents

--- a/docs/source/action.rst
+++ b/docs/source/action.rst
@@ -92,6 +92,10 @@ RightAction Methods
 -------------------
 .. autoclass:: RowActionBMat8
     :no-undoc-members:
-    :exclude-members: __init__
     :members:
-    :inherited-members:
+
+Runner Methods
+--------------
+.. autoclass:: RowActionBMat8
+   :noindex:
+   :inherited-members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -67,7 +67,6 @@ autoclass_content = "both"
 # replacements will be performed globally
 type_replacements = {
     r"libsemigroups::Presentation<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >": r"Presentation",
-    r"RowActionBMat8": r"RightAction",
     r"libsemigroups::BMat8": r"BMat8",
 }
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,24 +66,10 @@ autoclass_content = "both"
 # This dictionary should be of the form cpp type -> python type, and
 # replacements will be performed globally
 type_replacements = {
-    r"_libsemigroups_pybind11.KnuthBendixRewriteTrie": r"KnuthBendix",
     r"libsemigroups::Presentation<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >": r"Presentation",
     r"RowActionBMat8": r"RightAction",
     r"libsemigroups::BMat8": r"BMat8",
 }
-# to_replace = {"method", "function", "class"}
-
-
-def change_doc(app, what, name, obj, options, lines):
-    # if what in to_replace:
-    for i, line in enumerate(lines):
-        changes = 0
-        for typename, repl in type_replacements.items():
-            line, n = re.subn(typename, repl, line)
-            changes += n
-        if changes > 0:
-            lines[i] = line
-
 
 # This dictionary should be of the form class_name -> (pattern, repl), where
 # "pattern" should be replaced by "repl" in the signature of all functions in
@@ -118,5 +104,4 @@ def change_sig(app, what, name, obj, options, signature, return_annotation):
 
 
 def setup(app):
-    app.connect("autodoc-process-docstring", change_doc)
     app.connect("autodoc-process-signature", change_sig)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,6 +63,8 @@ intersphinx_mapping = {"python": ("https://docs.python.org/", None)}
 
 autoclass_content = "both"
 
+# This dictionary should be of the form cpp type -> python type, and
+# replacements will be performed globally
 type_replacements = {
     r"_libsemigroups_pybind11.KnuthBendixRewriteTrie": r"KnuthBendix",
     r"libsemigroups::Presentation<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >": r"Presentation",
@@ -83,13 +85,35 @@ def change_doc(app, what, name, obj, options, lines):
             lines[i] = line
 
 
+# This dictionary should be of the form class_name -> (pattern, repl), where
+# "pattern" should be replaced by "repl" in the signature of all functions in
+# "class_name"
+class_specific_replacements = {"RowActionBMat8": (r"\bBMat8\b", "Element")}
+
+
+def sub_if_not_none(pattern, repl, *strings):
+    out = []
+    for string in strings:
+        if string is None:
+            out.append(string)
+        else:
+            out.append(re.sub(pattern, repl, string))
+    return out
+
+
 def change_sig(app, what, name, obj, options, signature, return_annotation):
     # if what in to_replace:
     for typename, repl in type_replacements.items():
-        if signature is not None:
-            signature = re.sub(typename, repl, signature)
-        if return_annotation is not None:
-            return_annotation = re.sub(typename, repl, return_annotation)
+        signature, return_annotation = sub_if_not_none(
+            typename, repl, signature, return_annotation
+        )
+
+    for class_name, repl_pair in class_specific_replacements.items():
+        if class_name in name:
+            find, repl = repl_pair
+            signature, return_annotation = sub_if_not_none(
+                find, repl, signature, return_annotation
+            )
     return signature, return_annotation
 
 


### PR DESCRIPTION
In response to https://github.com/libsemigroups/libsemigroups_pybind11/pull/151#issuecomment-2053664044, this PR fixes the issue with the default constructor by using the doc of the function in `action.py`. It also changes `BMat8` to `element` in the signatures within the `RightAction` file, restores the hyperlinks in the return types, and includes the inherited `Runner` methods separately from the `RightAction` methods.