### PR TITLE
Add docstring directive

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,17 +5,53 @@ import os
 import subprocess
 import sphinx_rtd_theme
 import re
+from docutils import nodes
+from docutils.statemachine import StringList
+from sphinx.util.docutils import SphinxDirective
+from sphinx.ext.autodoc import ClassDocumenter, Options
+from sphinx.ext.autodoc.directive import DocumenterBridge
+
+# Custom Directive
+
+
+class ClassDescription(SphinxDirective):
+    required_arguments = 1
+
+    def run(self):
+        reporter = self.state.document.reporter
+
+        # generate the output
+        params = DocumenterBridge(
+            self.env,
+            reporter,
+            Options(),
+            self.lineno,
+            self.state,
+        )
+        documenter = ClassDocumenter(params, self.arguments[0])
+        documenter.generate()
+
+        # record all filenames as dependencies -- this will at least
+        # partially make automatic invalidation possible
+        for fn in params.record_dependencies:
+            self.state.document.settings.record_dependencies.add(fn)
+
+        node = nodes.paragraph()
+        node.document = self.state.document
+        params.result = StringList(documenter.get_doc()[0])
+        self.state.nested_parse(params.result, 0, node)
+        return node.children
 
 
 extensions = [
     "sphinx.ext.autodoc",
-    "sphinx.ext.intersphinx",
     "sphinx.ext.autosummary",
-    "sphinx.ext.napoleon",
+    "sphinx.ext.doctest",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
     "sphinx_copybutton",
     "sphinxcontrib.bibtex",
-    "sphinx.ext.doctest",
 ]
 
 bibtex_bibfiles = ["libsemigroups.bib"]
@@ -61,6 +97,8 @@ man_pages = [
 
 intersphinx_mapping = {"python": ("https://docs.python.org/", None)}
 
+autodoc_default_options = {"show-inheritence": True}
+
 autoclass_content = "both"
 
 # This dictionary should be of the form "bad type" -> "good type", and
@@ -104,3 +142,4 @@ def change_sig(app, what, name, obj, options, signature, return_annotation):
 
 def setup(app):
     app.connect("autodoc-process-signature", change_sig)
+    app.add_directive("classdoc", ClassDescription)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -6,15 +6,15 @@ import subprocess
 import sphinx_rtd_theme
 import re
 from docutils import nodes
-from docutils.statemachine import StringList
 from sphinx.util.docutils import SphinxDirective
-from sphinx.ext.autodoc import ClassDocumenter, Options
+from sphinx.ext.autodoc import Options
 from sphinx.ext.autodoc.directive import DocumenterBridge
+from sphinx.addnodes import desc_content
 
 # Custom Directive
 
 
-class ClassDescription(SphinxDirective):
+class DocstringDirective(SphinxDirective):
     required_arguments = 1
 
     def run(self):
@@ -24,11 +24,15 @@ class ClassDescription(SphinxDirective):
         params = DocumenterBridge(
             self.env,
             reporter,
-            Options(),
+            Options([("class-doc-from", "separated"), ("no-index", True)]),
             self.lineno,
             self.state,
         )
-        documenter = ClassDocumenter(params, self.arguments[0])
+
+        # look up target Documenter
+        objtype = self.name[:-9]  # strip suffix (-docstring).
+        doccls = self.env.app.registry.documenters[objtype]
+        documenter = doccls(params, self.arguments[0])
         documenter.generate()
 
         # record all filenames as dependencies -- this will at least
@@ -38,9 +42,8 @@ class ClassDescription(SphinxDirective):
 
         node = nodes.paragraph()
         node.document = self.state.document
-        params.result = StringList(documenter.get_doc()[0])
         self.state.nested_parse(params.result, 0, node)
-        return node.children
+        return list(node.traverse(condition=desc_content))
 
 
 extensions = [
@@ -142,4 +145,5 @@ def change_sig(app, what, name, obj, options, signature, return_annotation):
 
 def setup(app):
     app.connect("autodoc-process-signature", change_sig)
-    app.add_directive("classdoc", ClassDescription)
+    app.add_directive("classdocstring", DocstringDirective)
+    app.add_directive("functiondocstring", DocstringDirective)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -2,25 +2,28 @@
 # -*- coding: utf-8 -*-
 
 import os
+import re
 import subprocess
 import sphinx_rtd_theme
-import re
+import sys
 from docutils import nodes
+from sphinx.util import logging
 from sphinx.util.docutils import SphinxDirective
 from sphinx.ext.autodoc import Options
 from sphinx.ext.autodoc.directive import DocumenterBridge
 from sphinx.addnodes import desc_content
 
+logger = logging.getLogger(__name__)
+
 # Custom Directive
 
 
 class DocstringDirective(SphinxDirective):
+    # This will either be the class name or function name
     required_arguments = 1
 
     def run(self):
         reporter = self.state.document.reporter
-
-        # generate the output
         params = DocumenterBridge(
             self.env,
             reporter,
@@ -29,10 +32,11 @@ class DocstringDirective(SphinxDirective):
             self.state,
         )
 
-        # look up target Documenter
-        objtype = self.name[:-9]  # strip suffix (-docstring).
-        doccls = self.env.app.registry.documenters[objtype]
-        documenter = doccls(params, self.arguments[0])
+        # find and create the right type of Documenter
+        object_type = self.name[:-9]  # strip suffix (-docstring).
+        doc_class = self.env.app.registry.documenters[object_type]
+        documenter = doc_class(params, self.arguments[0])
+
         documenter.generate()
 
         # record all filenames as dependencies -- this will at least
@@ -40,10 +44,21 @@ class DocstringDirective(SphinxDirective):
         for fn in params.record_dependencies:
             self.state.document.settings.record_dependencies.add(fn)
 
+        # Parse the output to
         node = nodes.paragraph()
         node.document = self.state.document
         self.state.nested_parse(params.result, 0, node)
-        return list(node.traverse(condition=desc_content))
+
+        # Find the docstring portion of the output
+        docstring = list(node.findall(condition=desc_content))
+
+        if not docstring:
+            logger.warning(
+                f"The docstring for {self.arguments[0]} cannot be found."
+            )
+            return []
+
+        return docstring
 
 
 extensions = [
@@ -147,3 +162,4 @@ def setup(app):
     app.connect("autodoc-process-signature", change_sig)
     app.add_directive("classdocstring", DocstringDirective)
     app.add_directive("functiondocstring", DocstringDirective)
+    app.add_directive("methoddocstring", DocstringDirective)

--- a/docs/source/reporter.rst
+++ b/docs/source/reporter.rst
@@ -9,7 +9,8 @@
 Reporter
 ========
 
-.. classdoc:: Reporter
+.. classdocstring:: Reporter
+
 
 Contents
 --------

--- a/docs/source/reporter.rst
+++ b/docs/source/reporter.rst
@@ -9,9 +9,7 @@
 Reporter
 ========
 
-.. autoclass:: Reporter
-   :class-doc-from: class
-   :noindex:
+.. classdoc:: Reporter
 
 Contents
 --------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+docutils==0.20.1
 graphviz==0.20.1
 jinja2<3.1
 nose==1.3.7


### PR DESCRIPTION
@james-d-mitchell pointed out that it would be nice to be able to insert the docstring of a class into the documentation, without the need to include the signature. This functionality didn't seem to exist, so this PR implements it. It also allow for the addition of function docstrings.

The structure of `DocstringDirective` is based on Sphinx's `AutodocDirective` class from the `autodoc` extension, and therefore it would be quite simple to add add a `<python_object>docstring` directive for any `auto<python_object>` directive that exists in `autodoc` (see [here](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directives) for such directives).